### PR TITLE
Remove queries

### DIFF
--- a/index.php
+++ b/index.php
@@ -586,21 +586,15 @@ if(!isset($startday) || trim($startday) == "") //if startday is blank then looku
                 $result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred DESC LIMIT 1");
 				}
                 elseif($tripname == "None"){
-					$photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND ImageURL != ''");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND Comments != ''");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL ORDER BY DateOccurred");				}
                 elseif($tripname == "Any"){
-				    $photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND ImageURL != ''");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND Comments != ''");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred");
 				}
 				else {
-					$photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND ImageURL != '';");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND Comments != '';");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' ORDER BY DateOccurred");
@@ -613,21 +607,15 @@ if(!isset($startday) || trim($startday) == "") //if startday is blank then looku
                 $result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred DESC LIMIT 1");
 				}
                 elseif($tripname == "None"){
-					$photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND ImageURL != '' AND DateOccurred BETWEEN '$startday' AND '$endday'");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND Comments != '' AND DateOccurred BETWEEN '$startday' AND '$endday'");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");				}
                 elseif($tripname == "Any"){
-				    $photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND ImageURL != '' AND DateOccurred BETWEEN '$startday' AND '$endday'");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND Comments != '' AND DateOccurred BETWEEN '$startday' AND '$endday'");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");
 				}
 				else {
-					$photocount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND ImageURL != '' AND DateOccurred BETWEEN '$startday' AND '$endday';");
-					$commentcount  = mysql_query("SELECT COUNT(*) FROM  positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND Comments != ''AND DateOccurred BETWEEN '$startday' AND '$endday';");
 					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
 					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");
@@ -637,12 +625,18 @@ if(!isset($startday) || trim($startday) == "") //if startday is blank then looku
 $rounds      = 1;
 $total_miles = 0;
 $leg_time    = 0;
+                $pcount=0;
+                $ccount=0;
 	while($row = mysql_fetch_array($result))
 	{
 		$mph     = $row['Speed'] * 2.2369362920544;
 		$kph     = $row['Speed'] * 3.6;
 		$ft      = $row['Altitude'] * 3.2808399;
 		$meters  = $row['Altitude'];
+                    if ($row['ImageURL'] != '')
+                        $pcount++;
+                    if ($row['Comments'] != '')
+                        $ccount++;
 
 			if($rounds == 1)
 			{
@@ -673,13 +667,6 @@ if(isset($_REQUEST[last_location]))
 	{
 	$pcount=0;
 	$ccount=0;
-	}
-	else
-	{
-	$photocnt = mysql_fetch_array($photocount);
-	$commentcnt = mysql_fetch_array($commentcount);
-	$pcount=$photocnt[0];
-	$ccount=$commentcnt[0];
 	}
 
 				if(isset($_REQUEST[last_location]))   //if we are in live tracking then display this in center

--- a/index.php
+++ b/index.php
@@ -581,43 +581,27 @@ if(!isset($startday) || trim($startday) == "") //if startday is blank then looku
 {
 		if(isset($_REQUEST[last_location]))
                 {
-				$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID  ORDER BY DateOccurred DESC LIMIT 1");
-				$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID  ORDER BY DateOccurred DESC LIMIT 1");
                 $result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred DESC LIMIT 1");
 				}
                 elseif($tripname == "None"){
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL ORDER BY DateOccurred");				}
                 elseif($tripname == "Any"){
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred");
 				}
 				else {
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' ORDER BY DateOccurred");
 					}
 } else {   // lookup the start and end of trip based on dates given
 		if(isset($_REQUEST[last_location]))
                 {
-				$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID  ORDER BY DateOccurred DESC LIMIT 1");
-				$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID  ORDER BY DateOccurred DESC LIMIT 1");
                 $result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' ORDER BY DateOccurred DESC LIMIT 1");
 				}
                 elseif($tripname == "None"){
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID is NULL AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");				}
                 elseif($tripname == "Any"){
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");
 				}
 				else {
-					$tripstartdatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred LIMIT 1");
-					$tripenddatesql=mysql_query("Select DateOccurred FROM positions WHERE FK_Users_ID = $ID AND FK_Trips_ID= $trip AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred DESC LIMIT 1");
 					$result = mysql_query("SELECT * FROM positions WHERE FK_Users_ID='$ID' AND FK_Trips_ID='$trip' AND DateOccurred BETWEEN '$startday' AND '$endday' ORDER BY DateOccurred");
 					}
 }
@@ -638,11 +622,12 @@ $leg_time    = 0;
                     if ($row['Comments'] != '')
                         $ccount++;
 
+                    $endday = $row['DateOccurred'];
 			if($rounds == 1)
 			{
-				$holdtime = $row['DateOccurred'];
 				$total_time = 0;
 				$display_total_time = gmdate("H:i:s", $total_time);
+                        $startday = $endday;
 			}
 			else
 			{
@@ -650,19 +635,13 @@ $leg_time    = 0;
 				$total_miles      = $total_miles + $leg_miles;
 				$total_kilometers = $total_miles * 1.6;
 				$leg_time         = $row['DateOccurred'];
-				$total_time       = get_elapsed_time($holdtime, $leg_time);
+				$total_time       = get_elapsed_time($startday, $leg_time);
 				$total_time       = gmdate("H:i:s", $total_time);
 			}
 		$rounds++;
 		$holdlat  = $row['Latitude'];
 		$holdlong = $row['Longitude'];
 	}
-$tripstartdate = mysql_fetch_array($tripstartdatesql);
-$tripenddate = mysql_fetch_array($tripenddatesql);
-	$trips= $tripstartdate[DateOccurred];
-	$tripe= $tripenddate[DateOccurred];
- $startday = $tripstartdate[DateOccurred];
- $endday = $tripenddate[DateOccurred];
 if(isset($_REQUEST[last_location]))
 	{
 	$pcount=0;


### PR DESCRIPTION
This is removing a bunch of similar queries and calculates the result “manually” from the data. The reason is that it simplifies the introduction of PDO later as I don't have to change to many queries.

At some point in the future I'm going to provide a patch which is counting the number if image and comment markers in JavaScript (because it'll be possible to have a live view without refreshing) so that the query is not necessary anyway.
