### PR TITLE
Start session before using the variables #2

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 
+    session_start();
+
 	Require_once("config.php");
 
 


### PR DESCRIPTION
In 6403801 the `$_SESSION` variable was introduced but it was overlooked to
start the session before using it.
