### PR TITLE
Fix get_count call

### DIFF
--- a/index.php
+++ b/index.php
@@ -1040,7 +1040,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                         }
                         else
                         {
-                            $count = get_count("SELECT COUNT(*) FROM  positions " .
+                            $count = get_count("positions " .
                                                "WHERE FK_Users_ID='$ID' AND " .
                                                "FK_Trips_ID='$trip' AND " .
                                                "DateOccurred BETWEEN '$startday' AND '$endday'");


### PR DESCRIPTION
Previous instances of the patch d523b3e required a complete SQL request, but
the actual merged one automatically adds `SELECT COUNT(*) FROM`, and one call
introduced in 72d96b4 hasn't been updated for that. This should fix the issue described in #13.
