### PR TITLE
Remove usage of mysql_real_escape_string

### DIFF
--- a/index.php
+++ b/index.php
@@ -1167,7 +1167,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                         }
                         if($row['Comments'] != "")
                         {
-                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . mysql_real_escape_string($row['Comments']) . "<\/td><\/tr>";
+                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . $row['Comments'] . "<\/td><\/tr>";
                         }
                         $html .= "        <tr><td colspan=\"2\">$point_balloon_text " . $rounds . " of " . $count[0] . "<\/td><\/tr>";
                         if($row['ImageURL'])
@@ -1189,7 +1189,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                         }
                         if($row['Comments'] != "")
                         {
-                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . mysql_real_escape_string($row['Comments']) . "<\/td><\/tr>";
+                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . $row['Comments'] . "<\/td><\/tr>";
                         }
                         $html .= "        <tr><td colspan=\"2\">$point_balloon_text " . $rounds . " of " . $count[0] . "<\/td><\/tr>";
                         if($row['ImageURL'])
@@ -1241,7 +1241,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                         }
                         if($row['Comments'] != "")
                         {
-                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . mysql_real_escape_string($row['Comments']) . "<\/td><\/tr>";
+                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:<\/b> " . $row['Comments'] . "<\/td><\/tr>";
                         }
                         $html .= "        <tr><td colspan=\"2\">$point_balloon_text " . $rounds . " of " . $count[0] . "<\/td><\/tr>";
                         if($row['ImageURL'])
@@ -1265,7 +1265,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                         }
                         if($row['Comments'] != "")
                         {
-                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:</b> " . mysql_real_escape_string($row['Comments']) . "<\/td><\/tr>";
+                            $html .= "    <tr><td colspan=\"2\" align=\"left\" width=\"400\"><b>$comment_balloon_text:</b> " . $row['Comments'] . "<\/td><\/tr>";
                         }
                         $html .= "        <tr><td colspan=\"2\">$point_balloon_text " . $rounds . " of " . $count[0] . "<\/td><\/tr>";
                         if($row['ImageURL'])


### PR DESCRIPTION
Calling `mysql_real_escape_string` is not necessary when that result is fed
into the info box string because it does not handle HTML entities but MYSQL
query specific entities.

This fixes an issue with the PDO implementation in 13ae949 (as mentioned in #15) as calling the
function doesn't work if the file is not connected to the database.

I'm not sure this is the best way… but I'm not sure that the previous implementation was sensible anyway.
