### PR TITLE
Update Google Maps JavaScript API to version 3

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,8 +29,8 @@
     // or just leave blank if you do not want to use it
     $googleanalyticsaccount="";
 
-    // Google Maps default view (G_NORMAL_MAP,G_SATELLITE_MAP, G_HYBRID_MAP or G_PHYSICAL_MAP)
-    $googleview   = "G_NORMAL_MAP";
+    // Google Maps default view (ROADMAP, SATELLITE, HYBRID or TERRAIN)
+    $googleview   = "ROADMAP";
     //to show all map points when you arrive at the page and when you change trips (yes or no)
     $showmap="yes";
 
@@ -52,9 +52,6 @@
 
     // Click to center map (yes or no)
     $clickcenter  = "yes";
-
-    // Display map overview (yes or no)
-    $overview     = "yes";
 
     // Map auto-refresh in seconds (0 for manual refresh)
     $refresh      = "120";

--- a/index.php
+++ b/index.php
@@ -114,19 +114,6 @@
                 $clickcenter = $storeclickcenter;
             }
 
-			if($_REQUEST["setoverview"])
-            {
-                $overview    = "yes";
-            }
-            elseif($action == "form_display")
-            {
-                $overview    = "no";
-            }
-            else
-            {
-                $overview    = $storeoverview;
-            }
-
 			if($_REQUEST["setshowbearings"])
             {
                 $show_bearings    = "yes";
@@ -153,7 +140,6 @@
 
 	    $storecrosshair   = $crosshair;
             $storeclickcenter = $clickcenter;
-            $storeoverview    = $overview;
             $storeunits       = $units;
             $storelanguage    = $language;
    	    $storeshowbearings = $show_bearings;
@@ -167,7 +153,7 @@
             $html .= "            <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/>\n";
 			$html .= "            <link rel=\"shortcut icon\" href=\"favicon.ico\">\n";
             $html .= "            <title>$title_text (v" . $version_text . ")</title>\n";
-            $html .= "            <script src=\"https://maps.google.com/maps?file=api&amp;v=2.x&amp;key=$googleapikey\" type=\"text/javascript\"></script>\n";
+            $html .= "            <script src=\"https://maps.googleapis.com/maps/api/js?key=$googleapikey\" type=\"text/javascript\"></script>\n";
 			$html .= "        </head>\n";
             $html .= "        <body bgcolor=\"$bgcolor\">\n";
             $html .= "            <div align=center>\n";
@@ -181,7 +167,7 @@
             $html .= "            <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/>\n";
 			$html .= "            <link rel=\"shortcut icon\" href=\"favicon.ico\">\n";
             $html .= "            <title>$title_text (v" . $version_text . ")</title>\n";
-            $html .= "            <script src=\"https://maps.google.com/maps?file=api&amp;v=2.x&amp;key=$googleapikey\" type=\"text/javascript\"></script>\n";
+            $html .= "            <script src=\"https://maps.googleapis.com/maps/api/js?key=$googleapikey\" type=\"text/javascript\"></script>\n";
 			$html .= "        </head>\n";
             $html .= "        <body bgcolor=\"$bgcolor\">\n";
             $html .= "            <div align=center>\n";
@@ -223,7 +209,7 @@
                 $html .= "        <script type=\"text/javascript\" src=\"calendar.js\"></script>\n";
                 $html .= "        <script type=\"text/javascript\" src=\"lang/calendar-en.js\"></script>\n";
                 $html .= "        <script type=\"text/javascript\" src=\"calendar-setup.js\"></script>\n";
-		$html .= "        <script src=\"https://maps.google.com/maps?file=api&amp;v=2.x&amp;key=$googleapikey\" type=\"text/javascript\"></script>\n";
+		$html .= "        <script src=\"https://maps.googleapis.com/maps/api/js?key=$googleapikey\" type=\"text/javascript\"></script>\n";
                 $html .= "        <script type=\"text/javascript\" src=\"main.js\"></script>\n";
 		$html .= "    </head>\n";
 
@@ -758,14 +744,6 @@ if(isset($_REQUEST[last_location]))
                     {
                         $html .= "                    <input type=\"checkbox\" name=\"setclickcenter\"> $display_clickcenter_text<br>\n";
                     }
-                    if($overview == "yes")
-                    {
-                        $html .= "                    <input type=\"checkbox\" name=\"setoverview\" CHECKED> $display_overview_text<br>\n";
-                    }
-                    else
-                    {
-                        $html .= "                    <input type=\"checkbox\" name=\"setoverview\"> $display_overview_text<br><br>\n";
-                    }
                     $html .= "                        <select name=\"language\" class=\"pulldownlayout\">\n";
                     $html .= "                            <option value=\"english\""; if($language == "english") { $html .= " SELECTED"; } $html .= ">English</option>\n";
                     $html .= "                            <option value=\"italian\""; if($language == "italian") { $html .= " SELECTED"; } $html .= ">Italian</option>\n";
@@ -811,98 +789,54 @@ if(isset($_REQUEST[last_location]))
 sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     $html .= " </div>/n";
 
+                if ($googleview === "G_NORMAL_MAP")
+                    $googleview = "ROADMAP";
+                elseif ($googleview === "G_SATELLITE_MAP")
+                    $googleview = "SATELLITE";
+                elseif ($googleview === "G_HYBRID_MAP")
+                    $googleview = "HYBRID";
+                elseif ($googleview === "G_PHYSICAL_MAP")
+                    $googleview = "TERRAIN";
+
+                if ($googleview !== "ROADMAP" || $googleview !== "SATELLITE" ||
+                        $googleview !== "HYBRID" || $googleview !== "TERRAIN")
+                    // Invalid option
+                    $googleview = "ROADMAP";
 
                 $html .= "            <script type=\"text/javascript\">\n";
                 $html .= "            //<![CDATA[\n";
-                $html .= "                var iconRed = new GIcon();\n";
-                $html .= "                iconRed.image = '".$siteroot."red-dot.png';\n";
-                $html .= "                iconRed.shadow = '".$siteroot."msmarker.shadow.png';\n";
-                $html .= "                iconRed.iconSize = new GSize(32, 32);\n";
-                $html .= "                iconRed.shadowSize = new GSize(59, 32);\n";
-                $html .= "                iconRed.iconAnchor = new GPoint(15, 32);\n";
-                $html .= "                iconRed.infoWindowAnchor = new GPoint(5, 1);\n";
-
-                $html .= "                var iconLtBlue = new GIcon();\n";
-                $html .= "                iconLtBlue.image = '".$siteroot."mm_20_gray.png';\n";
-                $html .= "                iconLtBlue.shadow = '".$siteroot."mm_20_shadow.png';\n";
-                $html .= "                iconLtBlue.iconSize = new GSize(12, 20);\n";
-                $html .= "                iconLtBlue.shadowSize = new GSize(22, 20);\n";
-                $html .= "                iconLtBlue.iconAnchor = new GPoint(6, 19);\n";
-                $html .= "                iconLtBlue.infoWindowAnchor = new GPoint(5, 1);\n";
-
-                $html .= "                var iconLtYellow = new GIcon();\n";
-                $html .= "                iconLtYellow.image = '".$siteroot."mm_20_yellow.png';\n";
-                $html .= "                iconLtYellow.shadow = '".$siteroot."mm_20_shadow.png';\n";
-                $html .= "                iconLtYellow.iconSize = new GSize(12, 20);\n";
-                $html .= "                iconLtYellow.shadowSize = new GSize(22, 20);\n";
-                $html .= "                iconLtYellow.iconAnchor = new GPoint(6, 19);\n";
-                $html .= "                iconLtYellow.infoWindowAnchor = new GPoint(5, 1);\n";
-                
-                $html .= "                var iconLtPurple = new GIcon();\n";
-                $html .= "                iconLtPurple.image = '".$siteroot."mm_20_purple.png';\n";
-                $html .= "                iconLtPurple.shadow = '".$siteroot."mm_20_shadow.png';\n";
-                $html .= "                iconLtPurple.iconSize = new GSize(12, 20);\n";
-                $html .= "                iconLtPurple.shadowSize = new GSize(22, 20);\n";
-                $html .= "                iconLtPurple.iconAnchor = new GPoint(6, 19);\n";
-                $html .= "                iconLtPurple.infoWindowAnchor = new GPoint(5, 1);\n";
-
-                $html .= "                var iconGreen = new GIcon();\n";
-                $html .= "                iconGreen.image = '".$siteroot."green-dot.png';\n";
-                $html .= "                iconGreen.shadow = '".$siteroot."msmarker.shadow.png';\n";
-                $html .= "                iconGreen.iconSize = new GSize(32, 32);\n";
-                $html .= "                iconGreen.shadowSize = new GSize(59, 32);\n";
-                $html .= "                iconGreen.iconAnchor = new GPoint(15, 32);\n";
-                $html .= "                iconGreen.infoWindowAnchor = new GPoint(5, 1);\n";
-
-                $html .= "                var arrowIcons = [];\n";
-                $html .= "                for (angle = 0; angle < 360; angle += 45)\n";
-                $html .= "                {\n";
-                $html .= "                    var icon = new GIcon();\n";
-                $html .= "                    icon.image = '".$siteroot."arrow' + angle + '.png';\n";
-                $html .= "                    icon.iconSize = new GSize(16, 16);\n";
-                $html .= "                    icon.iconAnchor = new GPoint(15, 15);\n";
-                $html .= "                    icon.infoWindowAnchor = new GPoint(5, 1);\n";
-                $html .= "                    arrowIcons.push(icon);\n";
-                $html .= "                }\n";
-
                 $html .= "                var geocoder = null;\n";
                 $html .= "                var online = true;\n";
-                $html .= "                var bounds = new GLatLngBounds();\n";
-                $html .= "                var map = new GMap2(document.getElementById(\"map\"));\n";
-                $html .= "                map.setCenter(new GLatLng(0, 0), 0, $googleview);\n";
-                $html .= "                map.addControl(new GLargeMapControl());\n";
-                $html .= "                map.addControl(new GMapTypeControl());\n";
-                $html .= "                map.addControl(new GScaleControl());\n";
-                $html .= "                map.addMapType(G_PHYSICAL_MAP);\n";
-                $html .= "                map.enableScrollWheelZoom(); \n";
-                $html .= "            var centerCrosshair = new GIcon();\n";
+                $html .= "                var bounds = new google.maps.LatLngBounds();\n";
+                $html .= "                var map = new google.maps.Map(document.getElementById(\"map\"),\n";
+                $html .= "                                              {center: new google.maps.LatLng(0, 0),\n";
+                $html .= "                                               mapTypeId: google.maps.MapTypeId.$googleview,\n";
+                $html .= "                                               mapTypeControl: true,\n";
+                $html .= "                                               scrollwheel: true,\n";
+                $html .= "                                               scaleControl: true});\n";
+
                 if($crosshair == "yes")
                 {
-                    $html .= "            centerCrosshair.image = 'crosshair.gif';\n";
+                    $html .= "            var centerCrosshair = {\n";
+                    $html .= "                url: 'crosshair.gif',\n";
+                    $html .= "                size: new google.maps.Size(17, 17),\n";
+                    $html .= "                anchor: new google.maps.Point(8, 8)\n";
+                    $html .= "            };\n";
+                    $html .= "            centerCross = new google.maps.Marker({position: map.getCenter(),\n";
+                    $html .= "                                                  icon: centerCrosshair,\n";
+                    $html .= "                                                  clickable: false });\n";
+                    $html .= "            centerCross.setMap(map);\n";
+                    $html .= "            function setCenterCross() {\n";
+                    $html .= "                centerCross.setPosition(map.getCenter());\n";
+                    $html .= "            };\n";
+                    $html .= "            map.addListener(\"drag\", setCenterCross);\n";
+                    $html .= "            map.addListener(\"resize\", setCenterCross);\n";
+                    $html .= "            map.addListener(\"zoom_changed\", setCenterCross);\n";
+                    $html .= "            map.addListener(\"center_changed\", setCenterCross);\n";
                 }
-                else
-                {
-                    $html .= "            centerCrosshair.image = '';\n";
-                }
-                $html .= "            centerCrosshair.iconSize = new GSize(17, 17);\n";
-                $html .= "            centerCrosshair.iconAnchor = new GPoint(8, 8);\n";
-                $html .= "            centerCross = new GMarker(map.getCenter(), { icon: centerCrosshair, clickable: false }); map.addOverlay(centerCross);\n";
-                $html .= "            GEvent.addListener(map, \"drag\", function() { setCenterCross(); } );\n";
-                $html .= "            GEvent.addListener(map, \"resize\", function() { setCenterCross(); } );\n";
-                $html .= "            GEvent.addListener(map, \"zoomend\", function() { setCenterCross(); } );\n";
-                $html .= "            GEvent.addListener(map, \"wheelup\", function() { setCenterCross(); } );\n";
-                $html .= "            GEvent.addListener(map, \"wheeldown\", function() { setCenterCross(); } );\n";
-                $html .= "            function setCenterCross() {\n";
-                $html .= "                centerCross.setPoint(map.getCenter());\n";
-                $html .= "            };\n";
                 if($clickcenter == "yes")
                 {
-                    $html .= "            GEvent.addListener(map, \"click\", function(marker, point) { if(! marker) { map.panTo(point); map.setCenter(point); setCenterCross(); } } );\n";
-                }
-                if($overview == "yes")
-                {
-                    $html .= "            map.addControl(new GOverviewMapControl());\n";
-                    $html .= "            GEvent.addListener(map, \"move\", function() { setCenterCross(); } );\n";
+                    $html .= "            map.addListener(\"click\", function(e) { map.panTo(e.latLng); } );\n";
                 }
 
                 // Write configuration to JS
@@ -1028,7 +962,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     $kph     = $row['Speed'] * 3.6;
                     $ft      = $row['Altitude'] * 3.2808399;
                     $meters  = $row['Altitude'];
-                    $html .= "            var point = new GLatLng(" . $row['Latitude'] . "," . $row['Longitude'] . ");\n";
+                    $html .= "            var point = new google.maps.LatLng(" . $row['Latitude'] . "," . $row['Longitude'] . ");\n";
 
                     if($rounds == 1)
                     {
@@ -1046,15 +980,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
 
                     if (!is_null($row['URL']))
                     {
-                        $icon_shadow = str_replace( '.png', '.shadow.png', $row['URL']);
-                        $html .= "        var iconCustom" . $rounds . " = new GIcon();\n";
-                        $html .= "        iconCustom" . $rounds . ".image = '" . $row['URL'] . "';\n";
-                        $html .= "        iconCustom" . $rounds . ".shadow = '" . $icon_shadow . "';\n";
-                        $html .= "        iconCustom" . $rounds . ".iconSize = new GSize(32, 32);\n";
-                        $html .= "        iconCustom" . $rounds . ".shadowSize = new GSize(59, 32);\n";
-                        $html .= "        iconCustom" . $rounds . ".iconAnchor = new GPoint(15, 32);\n";
-                        $html .= "        iconCustom" . $rounds . ".infoWindowAnchor = new GPoint(5, 1);\n";
-                        $parameter = "iconCustom$rounds";
+                        $parameter = $row['URL'];
                     }
                     elseif($rounds == 1)
                     {
@@ -1095,22 +1021,12 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     $holdlat  = $row['Latitude'];
                     $holdlong = $row['Longitude'];
                 }
-                $html .= "        if (trip.markers.length > 1) {\n";
-                $html .= "            var points = [];\n";
-                $html .= "            for (i = 0; i < trip.markers.length; i++)\n";
-                $html .= "                points.push(trip.markers[i].getPoint());\n";
-                $html .= "            var polyline = new GPolyline(points, \"#000000\", 3, 1);\n";
-                $html .= "            map.addOverlay(polyline);\n";
-                $html .= "        }\n";
 
+                $html .= "        map.fitBounds(bounds); \n";
 		if(isset($_REQUEST[last_location])) //show last location is on
                                 {
 		$html .= "      document.zoomform.zoom.value = getValue(\"zoomlevel\"); \n";
-                $html .= " 	map.setZoom(map.getBoundsZoomLevel(bounds)-document.zoomform.zoom.value); \n";
-			        }
-				else
-				{
-                $html .= "                map.setZoom(map.getBoundsZoomLevel(bounds)-2); \n";
+                $html .= " 	map.setZoom(map.getZoom()-document.zoomform.zoom.value); \n";
 			        }
                 $html .= "                map.setCenter(bounds.getCenter());\n";
                 $html .= "            //]]>\n";

--- a/install.php
+++ b/install.php
@@ -120,7 +120,7 @@
             $fp = fwrite($configfile,"    // or just leave blank if you do not want to use\r\n");
             $fp = fwrite($configfile,"    \$googleanalyticsaccount   = \"$googleanalyticsaccount\";\r\n");
             $fp = fwrite($configfile,"    \r\n");
-            $fp = fwrite($configfile,"    // Google Maps default view (G_NORMAL_MAP,G_SATELLITE_MAP, G_HYBRID_MAP or G_PHYSICAL_MAP)\r\n");
+            $fp = fwrite($configfile,"    // Google Maps default view (ROADMAP, SATELLITE, HYBRID or TERRAIN)\r\n");
             $fp = fwrite($configfile,"    \$googleview   = \"$googleview\";\r\n");
             $fp = fwrite($configfile,"    \r\n");
             $fp = fwrite($configfile,"    //to show all map points when you arrive at the page and when you change trips\r\n");
@@ -144,9 +144,6 @@
             $fp = fwrite($configfile,"    \r\n");
             $fp = fwrite($configfile,"    // Click to center map (yes or no)\r\n");
             $fp = fwrite($configfile,"    \$clickcenter  = \"$clickcenter\";\r\n");
-            $fp = fwrite($configfile,"    \r\n");
-            $fp = fwrite($configfile,"    // Display map overview (yes or no) (yes or no)\r\n");
-            $fp = fwrite($configfile,"    \$overview     = \"$overview\";\r\n");
             $fp = fwrite($configfile,"    \r\n");
             $fp = fwrite($configfile,"    // Map auto-refresh in seconds (0 for manual refresh)\r\n");
             $fp = fwrite($configfile,"    \$refresh      = \"$refresh\";\r\n");
@@ -262,10 +259,10 @@
         $html .= "                  </td>\n";
         $html .= "                  <td align=\"left\">\n";
         $html .= "                      <select name=\"googleview\">\n";
-        $html .= "                          <option value=\"G_NORMAL_MAP\" SELECTED>Normal</option>\n";
-        $html .= "                          <option value=\"G_SATELLITE_MAP\">Satellite</option>\n";
-        $html .= "                          <option value=\"G_HYBRID_MAP\">Hybrid</option>\n";
-        $html .= "                          <option value=\"G_PHYSICAL_MAP\">Physical</option>\n";
+        $html .= "                          <option value=\"ROADMAP\" SELECTED>Normal</option>\n";
+        $html .= "                          <option value=\"SATELLITE\">Satellite</option>\n";
+        $html .= "                          <option value=\"HYBRID\">Hybrid</option>\n";
+        $html .= "                          <option value=\"TERRAIN\">Physical</option>\n";
         $html .= "                      </select>\n";
         $html .= "                  </td>\n";
         $html .= "              </tr>\n";
@@ -368,21 +365,6 @@
         if ($clickcenter)
         {
             $html .= "                      <option value=\"$clickcenter\" SELECTED>$clickcenter</option>";
-        }
-        $html .= "                          <option value=\"yes\">Yes</option>";
-        $html .= "                          <option value=\"no\">No</option>";
-        $html .= "                      </select>";
-        $html .= "                  </td>\n";
-        $html .= "              </tr>\n";
-        $html .= "              <tr>\n";
-        $html .= "                  <td align=\"right\">\n";
-        $html .= "                      Display map overview:\n";
-        $html .= "                  </td>\n";
-        $html .= "                  <td align=\"left\">\n";
-        $html .= "                      <select name=\"overview\">";
-        if ($overview)
-        {
-            $html .= "                      <option value=\"$overview\" SELECTED>$overview</option>";
         }
         $html .= "                          <option value=\"yes\">Yes</option>";
         $html .= "                          <option value=\"no\">No</option>";

--- a/main.js
+++ b/main.js
@@ -1,8 +1,25 @@
+var info = new google.maps.InfoWindow();
+var iconRed = 'red-dot.png';
+var iconLtBlue = 'mm_20_gray.png';
+var iconLtYellow = 'mm_20_yellow.png';
+var iconLtPurple = 'mm_20_purple.png';
+var iconGreen = 'green-dot.png';
+
+var arrowIcons = [];
+for (angle = 0; angle < 360; angle += 45)
+{
+    arrowIcons.push('arrow' + angle + '.png');
+}
+
 function Trip(name, user)
 {
     this.name = name;
     this.user = user;
     this.markers = [];
+    this.polyline = new google.maps.Polyline({strokeColor: "#000000",
+                                              strokeWeight: 3,
+                                              strokeOpacity: 1,
+                                              map: map});
 }
 
 Trip.prototype.lastMarker = function()
@@ -12,11 +29,16 @@ Trip.prototype.lastMarker = function()
 
 Trip.prototype.appendMarker = function(point, icon, data)
 {
-    var marker = new GMarker(point, icon);
-    GEvent.addListener(marker, "click", function() {marker.openInfoWindowHtml(data);});
-    map.addOverlay(marker);
-    bounds.extend(marker.getPoint());
+    var marker = new google.maps.Marker({position: point,
+                                         icon: icon});
+    marker.addListener("click", function() {
+        info.setContent(data);
+        info.open(map, marker);
+    });
+    marker.setMap(map);
+    bounds.extend(marker.getPosition());
     this.markers.push(marker);
+    this.polyline.getPath().push(point);
     return marker;
 }
 


### PR DESCRIPTION
This updates the Google Maps JavaScript API from version 2 to version 3. With
future APIs the overview map will be removed so the corresponding setting is
deprecated as well. Also the map types have changed but the old values will be
mapped. Because any notice would be printed at the top and thus generate
invalid HTML, it does not yet inform the user about the changes.

This also only adds the center cross related code if this option is actually
enabled.

Instead of building the polyline once at the end, it is now assigning a
polyline to the trip where adding a marker will cause it to be added to the
polyline automatically.
