### PR TITLE
Use PDO in the local cellid script

### DIFF
--- a/cellid_local.php
+++ b/cellid_local.php
@@ -1,15 +1,14 @@
 <?php
 
-require_once("config.php");
+require_once("database.php");
 
-if(!@mysql_connect("$DBIP","$DBUSER","$DBPASS"))
+$db = connect_save();
+
+if ($db === null)
 {
 	echo "Result:4";
 	die();
 }
-
-mysql_select_db("$DBNAME");
-	
 
 if ($_REQUEST["myl"] != "") 
 {
@@ -33,10 +32,10 @@ if ( $mcc == "" || $mnc == "" || $lac == "" || $cid == "" )
 }
 
 
-$result=mysql_query("Select latitude,longitude FROM cellids WHERE cellid='$mcc-$mnc-$lac-$cid' order by dateadded desc limit 0,1");
+$result = $db->exec_sql("SELECT Latitude, Longitude FROM cellids WHERE CellID=? ORDER BY DateAdded DESC LIMIT 0,1", "$mcc-$mnc-$lac-$cid");
 	
-if ( $row=mysql_fetch_array($result) )
-	echo "Result:0|".$row['latitude']."|".$row['longitude'];	
+if ( $row=$result->fetch() )
+        echo "Result:0|$row[Latitude]|$row[Longitude]";
 else
 	echo "Result:6"; // No lat/long for specified CellID
 


### PR DESCRIPTION
With 13ae949 the `mysql` calls have been changed to calls using the `PDO`
classes. This updates `cellid_local.php` to use `PDO` as well. It also uses
the proper capitalisation of the columns because at least the SQLite driver
is case sensitive.
