### PR TITLE
Separate comments and photo markers

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,11 @@ function getIcon(data)
         var direction = Math.floor((data.bearing + 22.5) / 45) % 8;
         return arrowIcons[direction];
     }
-    else if (data['photo'] || data['comment'])
+    else if (data['photo'])
+    {
+        return iconLtYellow;
+    }
+    else if (data['photo'])
     {
         return iconLtPurple;
     }


### PR DESCRIPTION
With 17d93d8 the markers having a comment or photo use a different (yellow)
marker. And then 086eb83 changed that into a purple marker. As it is intended
that in the future the marker uses a different marker having a photo anyway and
the yellow marker is still available it can be used as a place holder for now.
