### PR TITLE
Only use default map type if config is wrong

### DIFF
--- a/index.php
+++ b/index.php
@@ -798,8 +798,8 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                 elseif ($googleview === "G_PHYSICAL_MAP")
                     $googleview = "TERRAIN";
 
-                if ($googleview !== "ROADMAP" || $googleview !== "SATELLITE" ||
-                        $googleview !== "HYBRID" || $googleview !== "TERRAIN")
+                if ($googleview !== "ROADMAP" && $googleview !== "SATELLITE" &&
+                        $googleview !== "HYBRID" && $googleview !== "TERRAIN")
                     // Invalid option
                     $googleview = "ROADMAP";
 


### PR DESCRIPTION
With 4ee9f02 the map type defaulted to `ROADMAP` if it was not one of the
accepted ones. But the condition is only half inverted and thus will always
default to `ROADMAP` instead just when an incorrect was used.
