### PR TITLE
Actually check if marker has comment/photo

### DIFF
--- a/index.php
+++ b/index.php
@@ -988,10 +988,10 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     }
                     elseif($rounds > 1  && $rounds < $count[0])
                     {
-                        if (is_null($row['Angle']))
-                            $parameter = "getIcon({})";
-                        else
-                            $parameter = "getIcon({bearing: $row[Angle], comment: '$row[Comments]'})";
+                        $parameter = "getIcon({photo: '$row[ImageURL]', comment: '$row[Comments]'";
+                        if (!is_null($row['Angle']))
+                            $parameter .= ", bearing: $row[Angle]";
+                        $parameter .= "})";
                     }
                     else
                     {

--- a/main.js
+++ b/main.js
@@ -53,7 +53,7 @@ function getIcon(data)
     {
         return iconLtYellow;
     }
-    else if (data['photo'])
+    else if (data['comment'])
     {
         return iconLtPurple;
     }


### PR DESCRIPTION
In a11847f it checks if the photo is defined twice instead of checking if the
comment is defined in the second case.

Additionally the data to determine the icon did never contain information
about the photo so it would never use the photo marker.
