### PR TITLE
Use custom settings in later requests (#29)

### DIFF
--- a/index.php
+++ b/index.php
@@ -84,6 +84,7 @@
         $storeenddate      = $_REQUEST["storeenddate"];
         $startday          = preg_replace("/[^0-9 :\-]/", "", $_REQUEST["startday"]);
         $endday            = preg_replace("/[^0-9 :\-]/", "", $_REQUEST["endday"]);
+        $custom_view       = $_REQUEST["custom_view"];
 
         if ($action == "form_display" || $custom_view == "yes")
         {


### PR DESCRIPTION
When the settings are changed via the interface in the browser it adds a
custom parameter `action=form_display` which causes it to use the custom
settings provided as parameters. But that parameter is not persistent and
won't be included in future requests from that page (e.g. after changing the
trip) and in that case the `$custom_view` variable must be set to `yes`. Now
it is set to `yes` for the query but the script wasn't extracting the value
and thus the variable never contained the value `yes`.
