### PR TITLE
Show username in balloon

### DIFF
--- a/index.php
+++ b/index.php
@@ -342,6 +342,7 @@ if($public_page == "yes")
 } else {
                 $finduser = $db->exec_sql("Select * FROM users WHERE ID = ? LIMIT 1", $ID);
                 $founduser = $finduser->fetch();
+       $username = $founduser['username'];
        $html .= "                 $trip_data<br>\n";
        $html .= "                    " . $founduser["username"] . " (<a href=\"index.php?action=logout\">log out</a>)\n";
        if ($public_page == "no")


### PR DESCRIPTION
When the user needs to log in to see their routes, the username was missing
in the balloons with 3545d4d.
