### PR TITLE
Support loading a trip without specifying a user

### DIFF
--- a/index.php
+++ b/index.php
@@ -85,6 +85,12 @@
         $startday          = preg_replace("/[^0-9 :\-]/", "", $_REQUEST["startday"]);
         $endday            = preg_replace("/[^0-9 :\-]/", "", $_REQUEST["endday"]);
 
+        if (is_numeric($trip) && !isset($ID))
+        {
+            $ID = $db->exec_sql("SELECT FK_Users_ID FROM trips WHERE ID = ?",
+                                $trip)->fetchColumn();
+        }
+
         if ($action == "form_display" || $custom_view == "yes")
         {
 


### PR DESCRIPTION
If no user is given but a trip is set, it would previously overwrite that information as it would require the user. But if the trip is the ID it is unique over all trips of every user, so the user is not necessary and it can imply the user ID using the trip ID.
