### PR TITLE
Use same conversion factor

### DIFF
--- a/index.php
+++ b/index.php
@@ -632,7 +632,7 @@ $leg_time    = 0;
 			{
 				$leg_miles        = distance($row['Latitude'], $row['Longitude'], $holdlat, $holdlong, "m");
 				$total_miles      = $total_miles + $leg_miles;
-				$total_kilometers = $total_miles * 1.6;
+				$total_kilometers = $total_miles * 1.609344;
 				$leg_time         = $row['DateOccurred'];
 				$total_time       = get_elapsed_time($startday, $leg_time);
 				$total_time       = gmdate("H:i:s", $total_time);
@@ -979,12 +979,12 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     {
                         $leg_distance     = distance($row['Latitude'], $row['Longitude'], $holdlat, $holdlong, "k");
                         $total_distance  += $leg_distance;
-                        $total_miles      = $total_distance / 1.6;
-                        $total_kilometers = $total_distance;
                         $leg_time         = $row['DateOccurred'];
                         $total_time       = get_elapsed_time($holdtime, $leg_time);
                     }
                     $total_time       = gmdate("H:i:s", $total_time);
+                    $total_miles      = $total_distance / 1.609344;
+                    $total_kilometers = $total_distance;
 
                     if (!is_null($row['URL']))
                     {


### PR DESCRIPTION
Always use the same conversion factor to convert between miles and kilometers so that the total distance in the last marker and the summary are the same. This was introduced in 4fc6002c.

This also fixes the issue that the first marker shows the total distance from the previous calculation introduced in fcd60dbf for the metric variant and in 4fc6002c also for the imperial unit.

This fixes the issues described in #47.
