### PR TITLE
Conditionally show the button to delete trip

### DIFF
--- a/index.php
+++ b/index.php
@@ -414,7 +414,7 @@ if(isset($_REQUEST[last_location]))   //if we are in live tracking then display 
                     {
                         $html .= "                        <option value=\"$foundtrip[ID]\" SELECTED>$foundtrip[Name]</option>\n";
                         $tripname = $foundtrip[Name];
-                        $deleteButton = true;
+                        $deleteButton = $_SESSION["ID"] === $foundtrip["FK_Users_ID"];
                     }
                     else
                     {
@@ -422,7 +422,8 @@ if(isset($_REQUEST[last_location]))   //if we are in live tracking then display 
                     }
                 }
                 $html .= "                            </select>";
-                $html .= "<input type=\"button\" onclick=\"deleteTrip();\" class=\"pulldownlayout\" style=\"width:12px; text-align:center\" value=\"X\" id=\"delete-trip\">\n";
+                if ($deleteButton)
+                    $html .= "<input type=\"button\" onclick=\"deleteTrip();\" class=\"pulldownlayout\" style=\"width:12px; text-align:center\" value=\"X\" id=\"delete-trip\">\n";
 
 
                 $html .= "                            <input type=\"hidden\" name=\"ID\" value=\"$ID\">\n";


### PR DESCRIPTION
Instead of always showing the button to delete a trip, only show it when the owner of that trip is logged in.

This makes #3 a bit less severe but it doesn't stop anyone from constructing the query themselves (especially with #51 anyone can use their own browser). And in case you don't know the trip id you could just iterate over a bunch of them. In fact it is more like a “UI improvement”.

And the right side of the trip selection box is not aligned with the filter because it just removes the button. Now I think I know how to solve this but it would require a bit larger rewrite of that section which is why I deferred it to a later (yet to be written) patch. The issue is basically that it only knows how wide the selection box is, after it had written all the entries to the selection box and it can't rewrite the width.
