### PR TITLE
Lowercase kilometer abbreviation

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -60,7 +60,7 @@
     "unit-speed-imperial": "mph",
     "unit-distance-imperial": "Meilen",
     "unit-height-imperial": "Fuss",
-    "unit-speed-metric": "Km/h",
-    "unit-distance-metric": "Km",
+    "unit-speed-metric": "km/h",
+    "unit-distance-metric": "km",
     "unit-height-metric": "Meter"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -59,7 +59,7 @@
     "unit-speed-imperial": "mph",
     "unit-distance-imperial": "miles",
     "unit-height-imperial": "feet",
-    "unit-speed-metric": "Km/h",
-    "unit-distance-metric": "Km",
+    "unit-speed-metric": "km/h",
+    "unit-distance-metric": "km",
     "unit-height-metric": "meters"
 }


### PR DESCRIPTION
According to the SI definition, the abbreviations of units and prefixes are standardized and the `k` in `kilo` is to be written in lower case.

While it technically standardized not all languages actually follow that rule so this patch is only changes the languages in which I am sure that the lowercase variant is usually used.
