### PR TITLE
Select English entry by default

### DIFF
--- a/index.php
+++ b/index.php
@@ -795,7 +795,10 @@ if(isset($_REQUEST[last_location]))
                     $html .= "                        <select name=\"language\" class=\"pulldownlayout\">\n";
                     foreach (array_values($languages) as $lang_entry)
                     {
-                        $lang_name = strtolower($lang_entry->en);
+                        if ($lang_entry->en)
+                            $lang_name = strtolower($lang_entry->en);
+                        else
+                            $lang_name = "english";
                         $html .= "                            <option value=\"$lang_name\"";
                         if($language === $lang_name)
                             $html .= " SELECTED";


### PR DESCRIPTION
If there is no language selected it will default to English but actually preselect the first loaded language (usually the first alphebetically). This was because the English language doesn't define the language in English as it is the same as in its language.

But with ce41a7c the display used the English name to associate the used language with the preselected one.
