### PR TITLE
Properly unset ID if trip ID is invalid

### DIFF
--- a/index.php
+++ b/index.php
@@ -129,6 +129,8 @@
         {
             $ID = $db->exec_sql("SELECT FK_Users_ID FROM trips WHERE ID = ?",
                                 $trip)->fetchColumn();
+            if ($ID === false)
+                unset($ID);
         }
 
         if ($action == "form_display" || $custom_view == "yes")


### PR DESCRIPTION
With 3ae4b9f5 the ID could be implied if the trip ID is used. But when the trip ID is invalid, it instead returns `false` which looks to later comparisons that the ID is actually set. But it should default to the first user if the site is public.
