### PR TITLE
Fix zoom level when using live tracking

### DIFF
--- a/index.php
+++ b/index.php
@@ -1073,12 +1073,14 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     $holdlong = $row['Longitude'];
                 }
 
-                $html .= "        map.fitBounds(bounds); \n";
 		if(isset($_REQUEST[last_location])) //show last location is on
                                 {
-		$html .= "      document.zoomform.zoom.value = getValue(\"zoomlevel\"); \n";
-                $html .= " 	map.setZoom(map.getZoom()-document.zoomform.zoom.value); \n";
+                $html .= " 	map.setZoom(16 - document.zoomform.zoom.value); \n";
 			        }
+                else
+                {
+                    $html .= "        map.fitBounds(bounds); \n";
+                }
                 $html .= "                map.setCenter(bounds.getCenter());\n";
                 $html .= "            //]]>\n";
                 $html .= "            </script>\n";


### PR DESCRIPTION
The zoom level couldn't be calculated when using live tracking with 07d5546. Before that patch, when using live tracking, it determined the zoom level for the bounds and then subtracted the zoom level defined. But the zoom level will be always maximum as it is only one point, so it can always subtract the defined zoom level from 16.
