### PR TITLE
Correctly apply limit (#62)

### DIFF
--- a/index.php
+++ b/index.php
@@ -922,10 +922,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     }
                     if ($where != "")
                         $where .= " AND";
-                    if ($limit > 0)
-                        $limit = " DESC $limit";
-                    else
-                        $limit = "";
 
                     if ($tripname != "Any")
                     {
@@ -953,6 +949,10 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>/n";
                     $params[] = $startday;
                     $params[] = $endday;
                 }
+                if ($limit > 0)
+                    $limit = " DESC LIMIT $limit";
+                else
+                    $limit = "";
 
                 if ($showmap != "yes" && $showmapdata != 1)
                     $params[] = 'ZZ';


### PR DESCRIPTION
The limit when filtering the last 20 or using live tracking is applied incorreclty resulting in invalid queries since it was introduced in 1ecaf43. The queries are invalid because the `LIMIT` keyword is missing. Additionally it applies the same logic for both filtering variants.

If possible I'd appreciate if @nilsharm could test this patch itself to verify this will fix their issue.
