### PR TITLE
Redesign determining content for the trip selector

### DIFF
--- a/index.php
+++ b/index.php
@@ -412,7 +412,6 @@ if(isset($_REQUEST[last_location]))   //if we are in live tracking then display 
 
 
 		$html .= "                 $trip_title<br>\n";
-                $html .= "                        <select id=\"selTrip\" style=\"width:134px\" name=\"trip\" class=\"pulldownlayout trip\" onchange=\"javascript:submittrip();\" >\n";
 
                 $findtrips = $db->exec_sql("Select A1.*, (select min( A2.dateoccurred ) from positions A2 where A2.FK_TRIPS_ID=A1.ID) AS startdate  FROM trips A1 WHERE A1.FK_Users_ID = ? order by startdate desc ", $ID);
                 $foundTrips = array(array("ID" => "None", "Name" => $lang["trip-none"], "FK_Users_ID" => null),
@@ -430,6 +429,9 @@ if(isset($_REQUEST[last_location]))   //if we are in live tracking then display 
                 $deleteButton = ($selectedTrip["FK_Users_ID"] === $_SESSION["ID"]);
                 $trip = $selectedTrip["ID"];
                 $tripname = $selectedTrip["Name"];
+
+                $tripWidth = $deleteButton ? "style=\"width:134px\"" : "";
+                $html .= "                        <select id=\"selTrip\" $tripWidth name=\"trip\" class=\"pulldownlayout trip\" onchange=\"javascript:submittrip();\" >\n";
 
                 foreach ($foundTrips as $foundtrip)
                 {


### PR DESCRIPTION
This redesigns how it creates the trip selector by first querying all trips for a user and then determining which should be selected. The difference is that it then actively selects a default trip (which is either the latest trip or the None trip if there are no custom trips) if the used ID is invalid instead of letting the browser select a default value.

If it selected a default trip it not only selects it in the box but actually uses that information later to load the trip information. Previously this only happened if there wasn't a trip defined and not also when the trip is invalid.

Additionally it is now possible to determine if the selected trip is owned by the logged in user and can adjust the width of the selector accordingly.
