### PR TITLE
Convert download script

### DIFF
--- a/download.php
+++ b/download.php
@@ -1,4 +1,6 @@
 <?php
+
+    session_start();
   
   require_once('config.php');
     
@@ -20,13 +22,8 @@
   
   $showbearings = 0;
   
-// DMR Use the Cookies to get the user and password-->
-  if($public_page != "yes" && isset($_COOKIE["username"]) && isset($_COOKIE["password"]))
+    if (!isset($_SESSION["ID"]))
   {
-//      $loggedin = "yes";
-      $username = $_COOKIE["username"];
-      $password = $_COOKIE["password"];
-  } else {
     echo "<Result>Not Logged in or this is not a private system</Result>";
     die();
   }
@@ -42,16 +39,7 @@
   $showbearings = urldecode($_GET["sb"]);
     
   
-  $result=mysql_query("Select ID FROM users WHERE username = '$username' and password='$password'");
-  if ( $row=mysql_fetch_array($result) )
-  {
-      $userid=$row['ID'];   // Good, user and password are correct.
-  }
-  else
-  {
-    echo "Error: User/password not valid.";
-    die();    
-  }
+    $userid = $_SESSION["ID"];
   
   
         

--- a/download.php
+++ b/download.php
@@ -224,9 +224,9 @@
     
     // Main query
     if ($tripname == "<None>" )   
-      $sql = "select UNIX_TIMESTAMP(DateOccurred) as UnixDateOccured, DateOccurred,latitude, longitude,speed,altitude,fk_icons_id as customicon, null as tripname,A1.comments,A1.imageurl,A1.angle,A1.signalstrength,A1.signalstrengthmax,A1.signalstrengthmin,A1.batterystatus from positions A1 ";        
+      $sql = "select DateOccurred,latitude, longitude,speed,altitude,fk_icons_id as customicon, null as tripname,A1.comments,A1.imageurl,A1.angle,A1.signalstrength,A1.signalstrengthmax,A1.signalstrengthmin,A1.batterystatus from positions A1 ";
     else 
-      $sql = "select UNIX_TIMESTAMP(DateOccurred) as UnixDateOccured, DateOccurred,latitude, longitude,speed,altitude,fk_icons_id as customicon, A2.Name as tripname,A1.comments,A1.imageurl,A1.angle,A1.signalstrength,A1.signalstrengthmax,A1.signalstrengthmin,A1.batterystatus from positions A1 ";         
+      $sql = "select DateOccurred,latitude, longitude,speed,altitude,fk_icons_id as customicon, A2.Name as tripname,A1.comments,A1.imageurl,A1.angle,A1.signalstrength,A1.signalstrengthmax,A1.signalstrengthmin,A1.batterystatus from positions A1 ";
           
     $sql = $sql.$cond;
                 
@@ -259,6 +259,7 @@
         $altitudeM = number_format(0,2);
       }
       $angle = number_format($row['angle'],2);      
+      $row["UnixDateOccured"] = strtotime($row["DateOccurred"]);
       
       if ( $count == count($result) - 1) // Last pushpin
       {
@@ -529,11 +530,9 @@
 
     // Main query
     if ($tripname == "<None>" ) {   
-      $sql = "select UNIX_TIMESTAMP(DateOccurred) as DateOccured,latitude, longitude,speed,altitude,fk_icons_id as customicon, null as tripname,A1.comments,A1.imageurl,A1.angle from positions A1 ";
       $tripname = "None";       
-    } else { 
-      $sql = "select UNIX_TIMESTAMP(DateOccurred) as DateOccured,latitude, longitude,speed,altitude,fk_icons_id as customicon, A2.Name as tripname,A1.comments,A1.imageurl,A1.angle from positions A1 ";
     }         
+      $sql = "select DateOccurred,latitude, longitude,speed,altitude,fk_icons_id as customicon, A1.comments,A1.imageurl,A1.angle from positions A1 ";
 
     $sql = $sql.$cond;
     $result = $db->exec_sql($sql);
@@ -567,6 +566,7 @@
       //$wptdata.=" <sym>Dot</sym>\n";
       //$wptdata.=" <type><![CDATA[Dot]]></type>\n";
       $wptdata.="</wpt>\n";*/
+        $row["DateOccured"] = strtotime($row["DateOccurred"]);
       $trkptdata.="<trkpt lat=\"" . $row['latitude'] . "\" lon=\"" . $row['longitude'] . "\">\n";
       $trkptdata.=" <ele>" . $altitudeM . "</ele>\n";
       $trkptdata.=" <time>".date('Y-m-d',$row['DateOccured'])."T".date('H:i:s',$row['DateOccured'])."Z</time>\n";


### PR DESCRIPTION
The download script hasn't been changed so that 3545d4d broke it (as the cookie variable isn't used anymore). Additionally it can now use PDO which was introduced in e3ac335 but doesn't break it because the deprecated `mysql` functions still work.

This also removes the need for `UNIX_TIMESTAMP` as a function, which works in MySQL but I am for example usually test with a SQLite database which doesn't have that function, so the script is doing it itself and not the database software.
