### PR TITLE
Fix dt parameter for download

### DIFF
--- a/index.php
+++ b/index.php
@@ -728,7 +728,7 @@ if(isset($_REQUEST[last_location]))
 // Use the Cookie soe we don't display it in the URL        $ExportOptions .= "&p=" . $password;
                                         //
                                         $ExportOptions .= "&df=" . $startday;
-                                        $ExportOptions .= "&dt" . $endday;
+                                        $ExportOptions .= "&dt=" . $endday;
                                         $ExportOptions .= "&tn=" . $tripname;
                                         $ExportOptions .= "&sb=" . $storeshowbearings; //0=no 1=Yes
                                         $html .= "                                                    <a href=\"download.php?a=kml" . $ExportOptions . "\">KML Format</a><br>\n";


### PR DESCRIPTION
The download links did not define the `dt` parameter properly as the equal sign was missing between the name and value.
