### PR TITLE
Support translations with placeholders in JS

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -60,6 +60,7 @@
     "balloon-avg-speed": "Durchschnittstempo",
     "balloon-total-distance": "Entfernung",
     "balloon-point": "Punkt",
+    "balloon-point-val": "{0} von {1}",
     "balloon-comment": "Kommentar",
     "unit-speed-imperial": "mph",
     "unit-distance-imperial": "Meilen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -59,6 +59,7 @@
     "balloon-avg-speed": "Avg Speed",
     "balloon-total-distance": "Total Dist.",
     "balloon-point": "Point",
+    "balloon-point-val": "{0} of {1}",
     "balloon-comment": "Comments",
     "unit-speed-imperial": "mph",
     "unit-distance-imperial": "miles",

--- a/lang.js
+++ b/lang.js
@@ -1,6 +1,30 @@
 var lang = {
 
     get: function(key) {
+        var trans = this._get(key);
+        var args = Array.prototype.slice.call(arguments, 1);
+        if (args.length > 0)
+        {
+            trans = trans.replace(/({+)(\d+)(}+)/g, function(match, before, number, after) {
+                if (before.length == after.length && typeof args[number] != 'undefined')
+                {
+                    if (before.length % 2 == 0)
+                        var repl = number;
+                    else
+                        var repl = args[number];
+                    var count = Math.floor(before.length / 2);
+                    before = new Array(count).join('{');
+                    after = new Array(count).join('}');
+                    return before + repl + after;
+                }
+                else
+                    return match;
+            });
+        }
+        return trans;
+    },
+
+    _get: function(key) {
         // Extra check in case the mapping is still null
         if (this._trans && key in this._trans)
             return this._trans[key];

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ function createMarkerText(data)
         html += ("<tr><td colspan='2' align='left' width='400'><b>" +
                  lang.get('balloon-comment') + ":</b> " + data.comment + "</td></tr>");
     }
-    html += "        <tr><td colspan='2'>" + lang.get('balloon-point') + " " + (data.index + 1) + " of " + data.trip.markers.length + "</td></tr>";
+    html += "        <tr><td colspan='2'>" + lang.get('balloon-point') + " " + lang.get('balloon-point-val', data.index + 1, data.trip.markers.length) + "</td></tr>";
     if (data.photo)
     {
         html += ("    <tr><td colspan='2'><a href='" + data.photo +


### PR DESCRIPTION
The JavaScript translator now supports placeholder in the style of "{NUMBER}" to support strings like "X of Y" which is now "{0} of {1}". So this is now also translating the label which shows the current point number and number of points.

The reason it is not using simply a translation of "of" is that there might be cases in which other languages format the string differently and placeholders are more flexible. If there is a language which swaps for example the current and maximum, it is possible by doing something like "{1} foo {0}".
