### PR TITLE
Calculate marker information in JavaScript

### DIFF
--- a/index.php
+++ b/index.php
@@ -963,12 +963,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
 
                 $result = $query->fetchAll();
                 $count = count($result);
-                $avg_speed = 0;
-                foreach ($result as $row)
-                {
-                    $avg_speed += $row['Speed'];
-                }
-                $avg_speed /= $count;
 
                 if ($tripname == "Any")
                 {
@@ -1009,7 +1003,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
 
                     $formattedTS = escape_js_str(date($date_format, strtotime($row['DateOccurred'])));
 
-                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', speed: $row[Speed], avgSpeed: $avg_speed, altitude: $row[Altitude], comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
+                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', speed: $row[Speed], altitude: $row[Altitude], comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
                 }
 
 		if(isset($_REQUEST[last_location])) //show last location is on

--- a/index.php
+++ b/index.php
@@ -970,7 +970,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
                 }
                 $avg_speed /= $count;
 
-                $avg_kph = $avg_speed * 3.6;
                 if ($tripname == "Any")
                 {
                 $tripnameText = $trip_any_text;
@@ -987,7 +986,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
                 for ($rounds = 1; $rounds <= $count; $rounds++)
                 {
                     $row = $result[$rounds - 1];
-                    $kph     = $row['Speed'] * 3.6;
                     // escape the strings for JS
                     $row['ImageURL'] = escape_js_str($row['ImageURL']);
                     $row['Comments'] = escape_js_str($row['Comments']);
@@ -1011,7 +1009,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
 
                     $formattedTS = escape_js_str(date($date_format, strtotime($row['DateOccurred'])));
 
-                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', speed: $kph, avgSpeed: $avg_kph, altitude: $row[Altitude], comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
+                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', speed: $row[Speed], avgSpeed: $avg_speed, altitude: $row[Altitude], comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
                 }
 
 		if(isset($_REQUEST[last_location])) //show last location is on

--- a/index.php
+++ b/index.php
@@ -971,8 +971,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
                 $avg_speed /= $count;
 
                 $avg_kph = $avg_speed * 3.6;
-                $total_distance = 0;
-                $total_time = 0;
                 if ($tripname == "Any")
                 {
                 $tripnameText = $trip_any_text;
@@ -994,21 +992,6 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
                     $row['ImageURL'] = escape_js_str($row['ImageURL']);
                     $row['Comments'] = escape_js_str($row['Comments']);
 
-                    if($rounds == 1)
-                    {
-                        $holdtime = $row['DateOccurred'];
-                    }
-                    else
-                    {
-                        $leg_distance     = distance($row['Latitude'], $row['Longitude'], $holdlat, $holdlong, "k");
-                        $total_distance  += $leg_distance;
-                        $leg_time         = $row['DateOccurred'];
-                        $total_time       = get_elapsed_time($holdtime, $leg_time);
-                    }
-                    $total_time       = gmdate("H:i:s", $total_time);
-                    $total_miles      = $total_distance / 1.609344;
-                    $total_kilometers = $total_distance;
-
                     if (!is_null($row['URL']))
                     {
                         $parameter = "'$row[URL]'";
@@ -1028,9 +1011,7 @@ sa.com/central_eng.php\">Luis Espinosa</a></div>\n";
 
                     $formattedTS = escape_js_str(date($date_format, strtotime($row['DateOccurred'])));
 
-                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', totalTime: '$total_time', speed: $kph, avgSpeed: $avg_kph, altitude: $row[Altitude], totalDistance: $total_distance, comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
-                    $holdlat  = $row['Latitude'];
-                    $holdlong = $row['Longitude'];
+                    $html .= "        trip.appendMarker({latitude: $row[Latitude], longitude: $row[Longitude], timestamp: '$row[DateOccurred]', speed: $kph, avgSpeed: $avg_kph, altitude: $row[Altitude], comment: '$row[Comments]', photo: '$row[ImageURL]' $dataParameter, formattedTS: '$formattedTS'}, $parameter);\n";
                 }
 
 		if(isset($_REQUEST[last_location])) //show last location is on

--- a/main.js
+++ b/main.js
@@ -36,15 +36,37 @@ Trip.prototype.appendMarker = function(data, icon)
     var point = new google.maps.LatLng(data.latitude, data.longitude);
     var marker = new google.maps.Marker({position: point,
                                          icon: icon});
+    data.date = fromISO(data.timestamp);
+    if (this.markers.length > 0) {
+        data.distance = distance(this.lastMarker().getPosition(),
+                                 point);
+        var totalTime = (data.date.getTime() - this.markers[0].data.date.getTime()) / 1000;
+    } else {
+        data.distance = 0;
+        var totalTime = 0;
+    }
+    data.distanceToHere = this.totalDistance() + data.distance;
+    data.totalTime = (leadingZeros(totalTime / 3600) + ':' +
+                      leadingZeros(totalTime / 60 % 60) + ':' +
+                      leadingZeros(totalTime % 60))
     marker.addListener("click", function() {
         info.setContent(createMarkerText(data));
         info.open(map, marker);
     });
     marker.setMap(map);
     bounds.extend(marker.getPosition());
+    marker.data = data;
     this.markers.push(marker);
     this.polyline.getPath().push(point);
     return marker;
+}
+
+Trip.prototype.totalDistance = function()
+{
+    if (this.markers.length > 0)
+        return this.lastMarker().data.distanceToHere;
+    else
+        return 0;
 }
 
 function getIcon(data, lastMarker)
@@ -95,7 +117,7 @@ function createMarkerText(data)
                 data.totalTime + "</td></tr>");
     speed = toMiles(data.speed);
     avgSpeed = toMiles(data.avgSpeed);
-    totalDistance = toMiles(data.totalDistance);
+    totalDistance = toMiles(data.distanceToHere);
     altitude = data.altitude;
     if (!useMetric) {
         altitude *= 3.2808399;  // feet = 1 m
@@ -121,11 +143,19 @@ function createMarkerText(data)
     return html
 }
 
-function toMiles(distance)
+function leadingZeros(number)
 {
-    if (!useMetric)
-        distance *= 0.621371192;
-    return distance
+    number = Math.floor(number)
+    if (number < 10)
+        return '0' + number
+    else
+        return number
+}
+
+function fromISO(isoDate)
+{
+    var match = /(\d{4})-(\d?\d)-(\d?\d)[ _](\d?\d):(\d?\d):(\d?\d)/.exec(isoDate);
+    return new Date(match[1], match[2] - 1, match[3], match[4], match[5], match[6]);
 }
 
 var query = function(url, callback)
@@ -137,4 +167,33 @@ var query = function(url, callback)
     };
     req.open('GET', url, true);
     req.send(null);
+}
+
+/* Math helpers */
+
+function toMiles(distance)
+{
+    if (!useMetric)
+        distance *= 0.621371192;
+    return distance
+}
+
+function toRadians (angle) {
+  return angle * (Math.PI / 180);
+}
+
+function toDegrees (angle) {
+  return angle * (180 / Math.PI);
+}
+
+function distance(point1, point2) {
+    lat1 = toRadians(point1.lat());
+    lat2 = toRadians(point2.lat());
+    delta_lon = toRadians(point1.lng() - point2.lng());
+    if (Math.abs(lat1 - lat2) < 0.0000001 && Math.abs(delta_lon) < 0.0000001)
+        return 0;
+    dist = Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(delta_lon);
+    // Previous it was 1.1515 statue miles/min (1 min = 1/60 deg)
+    // This is the corresponding radius in kilometers
+    return Math.acos(dist) * 6370.69349;  // Average Earth radius in km
 }

--- a/main.js
+++ b/main.js
@@ -115,8 +115,8 @@ function createMarkerText(data)
                 "<td align='left'><b>" + lang.get('balloon-time') + ": </b>" + data.formattedTS +
                 "</td><td align='right'><b>" + lang.get('balloon-total-time') + ": </b>" +
                 data.totalTime + "</td></tr>");
-    speed = toMiles(data.speed);
-    avgSpeed = toMiles(data.avgSpeed);
+    speed = toMiles(data.speed * 3.6);
+    avgSpeed = toMiles(data.avgSpeed * 3.6);
     totalDistance = toMiles(data.distanceToHere);
     altitude = data.altitude;
     if (!useMetric) {

--- a/main.js
+++ b/main.js
@@ -69,6 +69,17 @@ Trip.prototype.totalDistance = function()
         return 0;
 }
 
+Trip.prototype.avgSpeed = function()
+{
+    // Return m/s, the same as data.speed and this.totalSpeed
+    if (this.markers.length > 0) {
+        var totalTime = (this.lastMarker().data.date.getTime() - this.markers[0].data.date.getTime()) / 1000;
+        return this.totalDistance() * 1000 / totalTime;
+    } else {
+        return 0;
+    }
+}
+
 function getIcon(data, lastMarker)
 {
     if (data.index == 0)
@@ -116,7 +127,7 @@ function createMarkerText(data)
                 "</td><td align='right'><b>" + lang.get('balloon-total-time') + ": </b>" +
                 data.totalTime + "</td></tr>");
     speed = toMiles(data.speed * 3.6);
-    avgSpeed = toMiles(data.avgSpeed * 3.6);
+    avgSpeed = toMiles(data.trip.avgSpeed() * 3.6);
     totalDistance = toMiles(data.distanceToHere);
     altitude = data.altitude;
     if (!useMetric) {


### PR DESCRIPTION
This calculates the distances, times and average inside JavaScript, so that it is easier to add markers dynamically. In the future it should be able to fetch new positions via JavaScript and add them to the existing trip.

It also fixes a minor issue showing the time elapsed of a marker, if the time elapsed is longer than (or equal to) 24 hours, as it'll wrap around.

The stored speed is changed to _meters per second_ to have it using the base units. Additionally the average speed is now just calculated by dividing the trip length and the time taken.

**This is undoing #76 which reverted #73:** The time now uses at least two digits for hours (e8501b2) and the average works the same as in #73, as it just divides the distance by the time taken and it doesn't average the speeds of each point (c2844b7).
