### PR TITLE
Fix account creation and detecting missing ones

### DIFF
--- a/database.php
+++ b/database.php
@@ -73,10 +73,10 @@
 
         function create_login($username, $password)
         {
-            $password = $this->static_hash($password);
+            $hash = $this->static_hash($password);
             $this->exec_sql("INSERT INTO users (username, password) ".
                             "VALUES (?, ?)",
-                            $username, $password);
+                            $username, $hash);
             return $this->valid_login($username, $password);
         }
 
@@ -85,7 +85,7 @@
             $user = $this->exec_sql("Select ID, password, Enabled " .
                                     "FROM users WHERE username=?",
                                     $username)->fetch();
-            if (is_null($user))
+            if ($user === false)
             {
                 return NO_USER;
             }


### PR DESCRIPTION
It previously couldn't detect that an account didn't exist, so it never returned that result. This is because fetching a row returns `false` and not `null`. Additionally it couldn't properly create a new account as it overwrote the password variable with the hash, and when logged in later it obviously didn't work because it hashed the hash again and they didn't match.

This was discovered in #81 and the reason for its revert in #82. I again tested the patch from #81 together with #84 and the issue reported issue was present and fixed with this one.
