### PR TITLE
Prepare requests to switch to PDO

### DIFF
--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -26,6 +26,16 @@
             return run(self::$connection);
         }
 
+        private function assertResult($result, $code=0, $values=0) {
+            $parts = explode("|", $result);
+            $this->assertEquals("Result:$code", $parts[0]);
+            if ($values === true) {
+                $this->assertGreaterThan(1, count($parts));
+            } else {
+                $this->assertEquals($values + 1, count($parts));
+            }
+        }
+
         public function setUp()
         {
             self::defineGET();
@@ -76,6 +86,12 @@
         public function testNoop()
         {
             $this->assertEquals("Result:0", self::runRequests());
+        }
+
+        public function testGetIconList()
+        {
+            $_GET["a"] = "geticonlist";
+            $this->assertResult(self::runRequests(), 0, true);
         }
 
     }


### PR DESCRIPTION
Using PDO instead of mysql commands makes it possible to use other database systems in the future. The mysql commands have also been removed in PHP 7 and with PDO it is possible to avoid SQL injection.

This will only change the verification structure to PDO and only changes the `geticonlist` action. Later patches can then change the more complicated queries mostly independently.

This is a fixed implementation of #81, after it has been reverted in #82.

Travis build: https://travis-ci.org/xZise/TrackMeViewer/builds/135559085
